### PR TITLE
update: add patch mode to vm

### DIFF
--- a/VM.tf
+++ b/VM.tf
@@ -34,6 +34,7 @@ resource "azurerm_windows_virtual_machine" "main" {
   admin_password           = local.passwordToUse
   provision_vm_agent       = true
   enable_automatic_updates = true
+  patch_mode               = var.patch_mode
 
   # timezone                 = "Eastern Standard Time"
 

--- a/variables.tf
+++ b/variables.tf
@@ -266,6 +266,7 @@ variable "winrm_script_url" {
 }
 
 variable "patch_mode" {
+  type        = string
   description = "Specifies the mode of in-guest patching to this Windows Virtual Machine. Possible values are `Manual`, `AutomaticByOS` and `AutomaticByPlatform`"
   default     = "AutomaticByPlatform"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -264,3 +264,8 @@ variable "winrm_script_url" {
   type        = string
   description = "URL of the WinRM powershell script from the storage account"
 }
+
+variable "patch_mode" {
+  description = "Specifies the mode of in-guest patching to this Windows Virtual Machine. Possible values are `Manual`, `AutomaticByOS` and `AutomaticByPlatform`"
+  default     = "AutomaticByPlatform"
+}


### PR DESCRIPTION
Specifies the mode of in-guest patching to this Windows Virtual Machine. Possible values are Manual, AutomaticByOS and AutomaticByPlatform. Defaults to AutomaticByOS.